### PR TITLE
Use GitHub workflow to update all branches

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,0 +1,30 @@
+name: Check for updates
+on:
+  schedule: # for scheduling to work this file must be in the default branch
+  - cron: "0 * * * *" # run every hour
+  workflow_dispatch: # can be manually dispatched under GitHub's "Actions" tab
+
+jobs:
+  flatpak-external-data-checker:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        branch: [ branch/21.08, branch/22.08 ] # list all branches to check
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ matrix.branch }}
+
+      - uses: docker://ghcr.io/flathub/flatpak-external-data-checker:latest
+        env:
+          GIT_AUTHOR_NAME: Flatpak External Data Checker
+          GIT_COMMITTER_NAME: Flatpak External Data Checker
+          # email sets "github-actions[bot]" as commit author, see https://github.community/t/github-actions-bot-email-address/17204/6
+          GIT_AUTHOR_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+          GIT_COMMITTER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+          EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          args: --update --never-fork org.freedesktop.Platform.VulkanLayer.OBSVkCapture.yml

--- a/flathub.json
+++ b/flathub.json
@@ -1,4 +1,5 @@
 {
 	"only-arches": ["x86_64"],
-	"skip-icons-check": true
+	"skip-icons-check": true,
+	"disable-external-data-checker": true
 }


### PR DESCRIPTION
It's super annoying to have to update all branches manually because the external data checker by default only creates PRs against the default branch (`master` in this case). Instead this PR adds a new [workflow](https://github.com/flathub/flatpak-external-data-checker#custom-workflow) that "manually" checks all the branches I want to update.